### PR TITLE
chore(ci): Ignore sonarcloud job for dependabot PRs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,7 @@ jobs:
           path: coverage/lcov.info
   sonarcloud:
     needs: unittest
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fix failing sonarcloud workflow in dependabot PRs